### PR TITLE
fix: #7 GitHub Action 在 MSVC 下未使用 Release 编译的问题

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: threeal/cmake-action@v2
         with:
           build-dir: ./build/obj/Release
+          build-args: --config Release
           options: |
             CMAKE_BUILD_TYPE=Release
           c-compiler: ${{ matrix.config.compiler-c || '' }}


### PR DESCRIPTION
fix: #7 GitHub Action 在 MSVC 下未使用 Release 编译的问题