### PR TITLE
fix: #14 修复当 Event 中两个事件 tick 相同时, 其先后顺序实际上取决于编译器和链接器实现的问题

### DIFF
--- a/source/include/frame/event.h
+++ b/source/include/frame/event.h
@@ -2,7 +2,6 @@
 
 #include "frame/common/event.h"
 #include <set>
-#include <tuple>
 
 namespace jx3calc {
 namespace frame {
@@ -55,17 +54,17 @@ private:
 
     class EventItem {
     public:
-        EventItem(event_tick_t tick, event_func_t func, void *self, void *param)
-            : tick(tick), func(func), self(self), param(param) {}
+        EventItem(event_tick_t tick, event_func_t func, void *self, void *param) :
+            tick(tick), func(func), self(self), param(param) {}
         event_tick_t tick;  // 生效时间
         event_func_t func;  // 回调函数
         void        *self;  // 回调函数的第一个参数
         void        *param; // 回调函数的第二个参数
         bool         operator<(const EventItem &other) const {
-            return std::tie(tick, func, self, param) < std::tie(other.tick, other.func, other.self, other.param);
+            return tick < other.tick;
         }
     };
-    static inline thread_local std::set<EventItem> eventList;
+    static inline thread_local std::multiset<EventItem> eventList;
 };
 
 } // namespace frame

--- a/source/src/frame/event.cpp
+++ b/source/src/frame/event.cpp
@@ -7,8 +7,8 @@ bool Event::run() {
     if (eventList.empty()) {
         return false;
     }
-    EventItem event = *eventList.begin();
-    eventList.erase(eventList.begin());
+    EventItem event = *eventList.begin(); // 复制构造, func, self, param 都是指针, 不会有问题
+    eventList.erase(eventList.begin());   // 删除迭代器指向的元素
     tick = event.tick;
     event.func(event.self, event.param);
     return true;
@@ -20,7 +20,14 @@ event_tick_t Event::add(event_tick_t delay, event_func_t func, void *self, void 
 }
 
 event_tick_t Event::cancel(event_tick_t active, event_func_t func, void *self, void *param) {
-    eventList.erase(EventItem(active, func, self, param));
+    // eventList.erase(EventItem(active, func, self, param));
+    auto range = eventList.equal_range(EventItem(active, func, self, param));
+    for (auto it = range.first; it != range.second; ++it) { // 无需再次判断 tick 是否相等
+        if (it->func == func && it->self == self && it->param == param) {
+            eventList.erase(it);
+            break;
+        }
+    }
     return active - tick;
 }
 


### PR DESCRIPTION
fix: #14 修复当 Event 中两个事件 tick 相同时, 其先后顺序实际上取决于编译器和链接器实现的问题